### PR TITLE
ci: add GitHub Actions workflow for build and test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Grant execute permission
+        run: chmod +x ./gradlew
+      - name: Build and run tests
+        run: ./gradlew clean build --no-daemon --stacktrace


### PR DESCRIPTION
This PR adds a basic CI workflow under .github/workflows/ci.yml that checks out the code, sets up JDK 17, and runs ./gradlew clean build on push and pull_request triggers to the main branch.