### PR TITLE
feature: add SpringBootTest for AIService bean instantiation and missing API key error handling

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,7 @@ This file lists pending tasks and features for the ai-agent project.
 
 - [x] Integrate `OpenAIService.getCompletion` with the real OpenAI HTTP API using the configured API key (e.g., via Spring WebClient), parse the JSON response, and return the generated text.
 - [x] Write unit/integration tests for `OpenAIService` HTTP integration (mock WebClient or use WireMock).
-- [ ] Add a Spring Boot Test or use `ApplicationContextRunner` to verify that when `openai.api.key` is set, the `AIService` bean is instantiated as `OpenAIService`.
+- [x] Add a Spring Boot Test or use `ApplicationContextRunner` to verify that when `openai.api.key` is set, the `AIService` bean is instantiated as `OpenAIService`.
 - [ ] Update CLI prompt handling to accept multiple command-line arguments (join `args[]` into a single prompt) and add tests covering multi-word prompts.
 - [ ] Implement clear error handling for missing or invalid API key: detect absence or invalid format early, print a descriptive "missing OPENAI_API_KEY" or "invalid API key" message, and add tests for these scenarios.
 - [ ] Expose OpenAI API parameters (`model`, `temperature`, `max_tokens`) via command-line flags or Spring properties with sensible defaults; update tests and documentation accordingly.

--- a/codex.md
+++ b/codex.md
@@ -1,7 +1,7 @@
 # Global Git/GH conventions
 - Always branch off `main` (never work directly on `main`).
 - Follow [Conventional Commits] (https://www.conventionalcommits.org/en/v1.0.0/) specification for commits and branches
-- Branch names should be `feature/<short-name>` or `bugfix/<short-name>`. Committ prefix ptions are limited to:
+- Branch names should be `feature/<short-name>` or `bugfix/<short-name>`. Committ prefix options are limited to:
     * feature
     * bugfix
     * chore

--- a/src/main/java/com/example/aiagent/Application.java
+++ b/src/main/java/com/example/aiagent/Application.java
@@ -16,7 +16,20 @@ public class Application implements CommandLineRunner {
     public static void main(String[] args) {
         SpringApplication app = new SpringApplication(Application.class);
         app.setBannerMode(Banner.Mode.OFF);
-        app.run(args);
+        try {
+            app.run(args);
+        } catch (Exception ex) {
+            Throwable cause = ex;
+            while (cause != null) {
+                if (cause instanceof IllegalStateException
+                    && cause.getMessage().contains("Missing OpenAI API key")) {
+                    System.out.println("Error: " + cause.getMessage());
+                    System.exit(1);
+                }
+                cause = cause.getCause();
+            }
+            throw ex;
+        }
     }
 
     @Override

--- a/src/test/java/com/example/aiagent/config/OpenAIConfigIntegrationTest.java
+++ b/src/test/java/com/example/aiagent/config/OpenAIConfigIntegrationTest.java
@@ -1,0 +1,29 @@
+package com.example.aiagent.config;
+
+import com.example.aiagent.config.TestConfig;
+import com.example.aiagent.service.AIService;
+import com.example.aiagent.service.OpenAIService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Integration test to verify that when the OpenAI API key property is set,
+ * the AIService bean is instantiated as OpenAIService.
+ */
+@SpringBootTest(classes = TestConfig.class,
+                  properties = "openai.api.key=test-key")
+class OpenAIConfigIntegrationTest {
+
+    @Autowired
+    private AIService aiService;
+
+    @Test
+    void whenApiKeyPresent_thenAIServiceIsOpenAIService() {
+        assertNotNull(aiService, "AIService bean should be instantiated");
+        assertTrue(aiService instanceof OpenAIService, "AIService should be an instance of OpenAIService");
+    }
+    
+}

--- a/src/test/java/com/example/aiagent/config/TestConfig.java
+++ b/src/test/java/com/example/aiagent/config/TestConfig.java
@@ -1,0 +1,14 @@
+package com.example.aiagent.config;
+
+import org.springframework.boot.SpringBootConfiguration;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Import;
+
+/**
+ * Test configuration to bootstrap a Spring Boot context for OpenAIConfig.
+ */
+@SpringBootConfiguration
+@EnableAutoConfiguration
+@Import(OpenAIConfig.class)
+public class TestConfig {
+}


### PR DESCRIPTION
This PR adds a Spring Boot integration test (OpenAIConfigIntegrationTest) to verify that when 'openai.api.key' is present, the AIService bean is instantiated as OpenAIService. It also enhances the Application main method to catch missing API key configuration and print a user-friendly error message before exiting with status 1.